### PR TITLE
feat(widget): add widget label

### DIFF
--- a/app/src/display/status_screen.c
+++ b/app/src/display/status_screen.c
@@ -71,5 +71,15 @@ lv_obj_t *zmk_display_status_screen() {
     lv_obj_align(zmk_widget_wpm_status_obj(&wpm_status_widget), NULL, LV_ALIGN_IN_BOTTOM_RIGHT, -12,
                  0);
 #endif
+
+#if IS_ENABLED(CONFIG_ZMK_WIDGET_LABEL)
+    lv_obj_t *label;
+    label = lv_label_create(screen, NULL);
+    lv_obj_set_style_local_text_font(label,
+                                     LV_LABEL_PART_MAIN, LV_STATE_DEFAULT,
+                                     lv_theme_get_font_small());
+    lv_label_set_text(label, CONFIG_ZMK_WIDGET_LABEL_TEXT);
+    lv_obj_align(label, NULL, LV_ALIGN_IN_TOP_LEFT, 0, 0);
+#endif
     return screen;
 }

--- a/app/src/display/widgets/Kconfig
+++ b/app/src/display/widgets/Kconfig
@@ -33,4 +33,17 @@ config ZMK_WIDGET_WPM_STATUS
     select LVGL_USE_LABEL
     select ZMK_WPM
 
+config ZMK_WIDGET_LABEL
+    bool "Widget for text label"
+    depends on !ZMK_SPLIT || ZMK_SPLIT_ROLE_CENTRAL
+    select LVGL_USE_LABEL
+
+if ZMK_WIDGET_LABEL
+
+config ZMK_WIDGET_LABEL_TEXT
+    string "Label widget text"
+    default ZMK_KEYBOARD_NAME
+
+endif # ZMK_WIDGET_LABEL
+
 endmenu


### PR DESCRIPTION
CONFIG_ZMK_DISPLAY=y
CONFIG_ZMK_WIDGET_LABEL=y
CONFIG_ZMK_WIDGET_LABEL_TEXT="custom label"

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->
## Board/Shield Check-list
 - [ ] This board/shield is tested working on real hardware
 - [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
 - [ ] `.zmk.yml` metadata file added
 - [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
 - [ ] General consistent formatting of DeviceTree files
 - [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
 - [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
 - [ ] If split, no name added for the right/peripheral half
 - [ ] Kconfig.defconfig file correctly wraps *all* configuration in conditional on the shield symbol
 - [ ] `.conf` file has optional extra features commented out
 - [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
